### PR TITLE
changing to main for branch in workflows

### DIFF
--- a/.github/workflows/render-index.yaml
+++ b/.github/workflows/render-index.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 name: render-index
 

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: master
+    branches: main
 
 name: render-README
 


### PR DESCRIPTION
noticed the main branch was still called master - updated the workflows